### PR TITLE
Fix link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A toolkit for visualizing CLIMA's results
 
 |||
 |---------------------:|:----------------------------------------------|
-| **Documentation**    | [![latest][docs-latest-img]][docs-latest-url] |
+| **Documentation**    | [![latest][docs-dev-img]][docs-dev-url]       |
 | **Azure Build**      | [![azure][azure-img]][azure-url]              |
 | **Code Coverage**    | [![codecov][codecov-img]][codecov-url]        |
 | **Bors**             | [![Bors enabled][bors-img]][bors-url]         |
 
-[docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
-[docs-latest-url]: https://CliMA.github.io/VizCLIMA.jl/latest/
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: https://CliMA.github.io/VizCLIMA.jl/dev/
 
 [azure-img]: https://dev.azure.com/climate-machine/VizCLIMA/_apis/build/status/climate-machine.VizCLIMA.jl?branchName=master
 [azure-url]: https://dev.azure.com/climate-machine/VizCLIMA/_build/latest?definitionId=8&branchName=master

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ pages = Any[
 makedocs(
   sitename = "VizCLIMA.jl",
   doctest = false,
-  strict = false,
+  strict = true,
   format = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true",
         mathengine = MathJax(Dict(
@@ -18,11 +18,13 @@ makedocs(
         ))
   ),
   clean = false,
-  modules = [Documenter, VizCLIMA],
+  modules = [VizCLIMA],
   pages = pages,
 )
 
 deploydocs(
-           repo = "github.com/CliMA/VizCLIMA.jl.git",
-           target = "build",
-          )
+    repo = "github.com/CliMA/VizCLIMA.jl.git",
+    target = "build",
+    push_preview = true,
+    forcepush = true,
+)


### PR DESCRIPTION
 - Fixes docs README to point to the correct URL
 - Turn on push previews
 - Turn on `strict = true`

Closes #16.